### PR TITLE
Add preview image caching for faster UI updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Neg2Posi
+
+## Preview caching
+
+Neg2Posi now keeps a small in-memory cache of preview results to make tone
+adjustment sliders and crop edits much more responsive. Each cache entry stores
+the original "before" image along with the heavy-weight processing output
+before tone adjustments. Entries are keyed by the normalized source path, film
+type, and current manual crop signature, and are automatically invalidated when
+the source file timestamp or crop overrides change. The Qt UI flushes the cache
+on exit to release memory.

--- a/main.py
+++ b/main.py
@@ -59,6 +59,7 @@ def apply_raw_flat_field(path: str, img: np.ndarray) -> np.ndarray:
 
 import os
 import lensfunpy
+import threading
 
 def apply_lensfun_correction(path: str, img: np.ndarray) -> np.ndarray:
     """
@@ -152,6 +153,18 @@ class AdjustmentState:
 _current_adjustments = AdjustmentState()
 
 
+@dataclass
+class PreviewCacheEntry:
+    key: tuple[str, str, str]
+    mtime: float
+    before: np.ndarray
+    intermediate: np.ndarray
+
+
+_preview_cache: dict[tuple[str, str, str], PreviewCacheEntry] = {}
+_preview_cache_lock = threading.Lock()
+
+
 def set_adjustments(brightness: float, cyan: float, magenta: float, yellow: float) -> None:
     """Update global tone adjustment settings."""
 
@@ -166,6 +179,75 @@ def get_adjustments() -> tuple[float, float, float, float]:
 
     adj = _current_adjustments
     return adj.brightness, adj.cyan, adj.magenta, adj.yellow
+
+
+def _preview_override_signature(
+    path: str | os.PathLike[str],
+    override_pts: Iterable[tuple[float, float]] | np.ndarray | None,
+) -> str:
+    pts = _prepare_override_points(override_pts)
+    if pts is None:
+        stored_pts = _lookup_override_points(path)
+        pts = _prepare_override_points(stored_pts)
+        if pts is None:
+            return "auto"
+    angle = _lookup_override_angle(path)
+    flattened = ",".join(f"{coord:.4f}" for coord in pts.flatten())
+    return f"manual:{flattened}|{angle:.4f}"
+
+
+def _preview_cache_key(
+    path: str | os.PathLike[str], film_type: str, override_signature: str
+) -> tuple[str, str, str]:
+    return _normalize_path_key(path), film_type, override_signature
+
+
+def _get_or_create_preview_entry(
+    in_path: str,
+    film_type: str,
+    override_pts: Iterable[tuple[float, float]] | np.ndarray | None = None,
+    preloaded_before: np.ndarray | None = None,
+    low_pct: float = 0.5,
+    high_pct: float = 99.5,
+) -> PreviewCacheEntry:
+    path_obj = Path(in_path)
+    mtime = path_obj.stat().st_mtime
+    override_signature = _preview_override_signature(in_path, override_pts)
+    cache_key = _preview_cache_key(in_path, film_type, override_signature)
+    with _preview_cache_lock:
+        entry = _preview_cache.get(cache_key)
+        if entry is not None and entry.mtime == mtime:
+            return entry
+    before = (
+        np.array(preloaded_before, dtype=np.float32, copy=False)
+        if preloaded_before is not None
+        else load_image(in_path)
+    )
+    core = _process_loaded_image_core(
+        before,
+        in_path,
+        film_type,
+        low_pct,
+        high_pct,
+        override_pts=override_pts,
+    )
+    entry = PreviewCacheEntry(cache_key, mtime, before, core)
+    with _preview_cache_lock:
+        _preview_cache[cache_key] = entry
+    return entry
+
+
+def _invalidate_preview_cache(path: str | os.PathLike[str]) -> None:
+    norm = _normalize_path_key(path)
+    with _preview_cache_lock:
+        keys_to_remove = [key for key in _preview_cache if key[0] == norm]
+        for key in keys_to_remove:
+            _preview_cache.pop(key, None)
+
+
+def _clear_preview_cache() -> None:
+    with _preview_cache_lock:
+        _preview_cache.clear()
 
 
 def set_manual_crop_points(
@@ -187,6 +269,7 @@ def clear_manual_crop(path: str | os.PathLike[str]) -> None:
     """Remove any stored manual crop/angle overrides for *path*."""
 
     norm_key = _normalize_path_key(path)
+    _invalidate_preview_cache(path)
     for key in list(user_crops.keys()):
         if _normalize_path_key(key) == norm_key:
             user_crops.pop(key, None)
@@ -261,6 +344,7 @@ def _store_user_override(
 ) -> None:
     """Persist manual crop *pts* and *angle* under raw and normalized keys."""
 
+    _invalidate_preview_cache(path)
     norm_key = _normalize_path_key(path)
     raw_key = str(path)
     keys_to_keep = {raw_key, norm_key}
@@ -445,7 +529,7 @@ def _apply_tone_adjustments(img: np.ndarray) -> np.ndarray:
     return np.clip(out, 0.0, 1.0)
 
 
-def _process_loaded_image(
+def _process_loaded_image_core(
     img_original: np.ndarray,
     in_path: str,
     film_type: str,
@@ -453,7 +537,7 @@ def _process_loaded_image(
     high_pct: float,
     override_pts: Iterable[tuple[float, float]] | np.ndarray | None = None,
 ) -> np.ndarray:
-    """Run the full processing pipeline starting from a preloaded image."""
+    """Run the heavy pipeline steps and return the image before tone tweaks."""
 
     img = np.array(img_original, dtype=np.float32, copy=True)
 
@@ -474,9 +558,28 @@ def _process_loaded_image(
     img_geom = _apply_geometry(img, film_type, pts_array, angle)
 
     if film_type == FILM_TYPE_BW_INTERNAL_KEY:
-        img_corr = process_bw_pipeline(img_geom, low_pct, high_pct, apply_geometry=False)
-    else:
-        img_corr = process_color_pipeline(img_geom, low_pct, high_pct, apply_geometry=False)
+        return process_bw_pipeline(img_geom, low_pct, high_pct, apply_geometry=False)
+    return process_color_pipeline(img_geom, low_pct, high_pct, apply_geometry=False)
+
+
+def _process_loaded_image(
+    img_original: np.ndarray,
+    in_path: str,
+    film_type: str,
+    low_pct: float,
+    high_pct: float,
+    override_pts: Iterable[tuple[float, float]] | np.ndarray | None = None,
+) -> np.ndarray:
+    """Run the full processing pipeline starting from a preloaded image."""
+
+    img_corr = _process_loaded_image_core(
+        img_original,
+        in_path,
+        film_type,
+        low_pct,
+        high_pct,
+        override_pts=override_pts,
+    )
     return _apply_tone_adjustments(img_corr)
 
 
@@ -892,17 +995,20 @@ ALLOWED_EXTS = ('.jpg', '.jpeg', '.png', '.bmp', '.tif', '.tiff',
                 '.dng', '.cr2', '.nef', '.arw', '.raf')
 
 def _preview_images(in_path: str, film_type: str):
-    before = load_image(in_path)
     override_pts = _lookup_override_points(in_path)
-    after = _process_loaded_image(
-        before,
-        in_path,
-        film_type,
-        low_pct=0.5,
-        high_pct=99.5,
-        override_pts=override_pts,
-    )
-    return before, after
+    try:
+        entry = _get_or_create_preview_entry(
+            in_path,
+            film_type,
+            override_pts=override_pts,
+            low_pct=0.5,
+            high_pct=99.5,
+        )
+    except FileNotFoundError:
+        _invalidate_preview_cache(in_path)
+        raise
+    after = _apply_tone_adjustments(entry.intermediate)
+    return entry.before, after
 
 
 def _apply_crop_editor(
@@ -937,7 +1043,16 @@ def _apply_crop_editor(
     pts_for_storage = [(float(x), float(y)) for x, y in new_pts_ordered]
     _store_user_override(path, pts_for_storage, angle)
 
-    return _preview_images(path, film_type)
+    entry = _get_or_create_preview_entry(
+        path,
+        film_type,
+        override_pts=new_pts_ordered,
+        preloaded_before=img_original,
+        low_pct=0.5,
+        high_pct=99.5,
+    )
+    after = _apply_tone_adjustments(entry.intermediate)
+    return entry.before, after
 
 
 def get_manual_crop_settings(path: str) -> tuple[dict[str, float], float]:
@@ -1006,6 +1121,7 @@ def launch_qt_ui() -> None:
         set_manual_crop_points=set_manual_crop_points,
         get_manual_crop_points=get_manual_crop_points,
         clear_manual_crop=clear_manual_crop,
+        clear_preview_cache=_clear_preview_cache,
         allowed_extensions=ALLOWED_EXTS,
     )
     run_qt_app(api)

--- a/ui_qt/main_window.py
+++ b/ui_qt/main_window.py
@@ -19,6 +19,7 @@ class ProcessingAPI:
     set_manual_crop_points: Callable[[str, Iterable[Tuple[float, float]], float], None]
     get_manual_crop_points: Callable[[str], Optional[List[Tuple[float, float]]]]
     clear_manual_crop: Callable[[str], None]
+    clear_preview_cache: Callable[[], None]
     allowed_extensions: Tuple[str, ...]
 
 
@@ -746,6 +747,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
 def run_qt_app(api: ProcessingAPI) -> None:
     app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    app.aboutToQuit.connect(api.clear_preview_cache)  # type: ignore[arg-type]
     window = MainWindow(api)
     window.resize(1200, 700)
     window.show()


### PR DESCRIPTION
## Summary
- introduce a preview cache that stores original and pre-tone images keyed by path, film type, and crop overrides
- reuse cached intermediates for slider updates and crop edits while clearing entries on manual changes or UI shutdown
- document the new caching behaviour in the README

## Testing
- python -m compileall main.py ui_qt/main_window.py

------
https://chatgpt.com/codex/tasks/task_b_68dd087033a083259d5b579438ff0ea3