### PR TITLE
Refine preview cache for tone slider updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Neg2Posi
+
+## Preview caching
+
+Neg2Posi now keeps a small in-memory cache of preview results to make tone
+adjustment sliders and crop edits much more responsive. Each cache entry stores
+the original "before" image along with the heavy-weight processing output
+before tone adjustments. Entries are keyed by the normalized source path, film
+type, and current manual crop signature, and are automatically invalidated when
+the source file timestamp or crop overrides change. The Qt UI flushes the cache
+on exit to release memory. Tone adjustment sliders reuse the cached
+intermediate frame and reapply colour tweaks in real time, avoiding repeated
+RAW/geometry processing work.


### PR DESCRIPTION
## Summary
- add a shared helper to resolve preview cache entries and expose a cached-after preview accessor
- update the Qt tone slider handling to reuse cached intermediates without reprocessing heavy stages
- document the real-time tone adjustment reuse in the README

## Testing
- python -m compileall main.py ui_qt/main_window.py

------
https://chatgpt.com/codex/tasks/task_b_68dd087033a083259d5b579438ff0ea3