### PR TITLE
Add macOS packaging spec with lensfun dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+!packaging/macos.spec
 
 # Installer logs
 pip-log.txt

--- a/README.md
+++ b/README.md
@@ -9,3 +9,17 @@ before tone adjustments. Entries are keyed by the normalized source path, film
 type, and current manual crop signature, and are automatically invalidated when
 the source file timestamp or crop overrides change. The Qt UI flushes the cache
 on exit to release memory.
+
+## Packaging (macOS)
+
+Build the standalone macOS bundle from a clean virtual environment so that
+PyInstaller can collect the `liblensfun` dependencies shipped with
+`lensfunpy`:
+
+```bash
+pyinstaller packaging/macos.spec --windowed --noconfirm
+```
+
+After building, test the bundle on a macOS system that does not have a
+system-wide installation of lensfun to confirm that the GUI launches and that
+lens correction features function as expected.

--- a/packaging/macos.spec
+++ b/packaging/macos.spec
@@ -1,0 +1,85 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+import os
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs
+
+block_cipher = None
+
+project_root = Path(__file__).resolve().parents[1]
+
+
+def _relocate_binaries(entries, destination):
+    relocated = []
+    for src, _ in entries:
+        basename = os.path.basename(src)
+        relocated.append((src, os.path.join(destination, basename)))
+    return relocated
+
+
+def _relocate_datas(entries, destination):
+    relocated = []
+    for src, dest in entries:
+        relocated.append((src, os.path.join(destination, dest)))
+    return relocated
+
+
+datas = []
+binaries = []
+hiddenimports = []
+
+lensfun_binaries = collect_dynamic_libs("lensfunpy")
+lensfun_datas = collect_data_files("lensfunpy")
+
+binaries += _relocate_binaries(
+    lensfun_binaries, os.path.join("Contents", "Frameworks")
+)
+datas += _relocate_datas(lensfun_datas, os.path.join("Contents", "Resources"))
+
+
+a = Analysis(
+    [str(project_root / "main.py")],
+    pathex=[str(project_root)],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name="Neg2Posi",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+app = BUNDLE(
+    exe,
+    name="Neg2Posi.app",
+    icon=None,
+    bundle_identifier=None,
+)


### PR DESCRIPTION
## Summary
- add a macOS-specific PyInstaller spec that collects lensfunpy binaries and data into the app bundle
- ensure the tracked spec file is exempt from the existing *.spec ignore rule
- document the macOS packaging command and verification guidance in the README

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68fae4abd9648325bb074c32464b31e7